### PR TITLE
dockerのコンテナ名をcovid19-mieに変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   app:
-    container_name: covid19
+    container_name: covid19-mie
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- close #60 

## ⛏ 変更内容 / Details of Changes
- `docker-compose.yml`のcontainer_nameをcovid19-mieに変更
