### PR TITLE
ogp, canonicalのURLを古いドメインから新しいドメインに変更

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -61,7 +61,7 @@ export default Vue.extend({
       link: [
         {
           rel: 'canonical',
-          href: `https://covid19-mie.netlify.com${this.$route.path}`
+          href: `https://mie.stopcovid19.jp${this.$route.path}`
         }
       ]
     }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,9 @@
 import { Configuration } from '@nuxt/types'
+const path = require('path')
 const purgecss = require('@fullhuman/postcss-purgecss')
 const autoprefixer = require('autoprefixer')
+
+const DOMAIN_URL = 'https://mie.stopcovid19.jp'
 
 const config: Configuration = {
   mode: 'universal',
@@ -30,7 +33,7 @@ const config: Configuration = {
       {
         hid: 'og:url',
         property: 'og:url',
-        content: 'https://covid19-mie.netlify.com/'
+        content: DOMAIN_URL
       },
       {
         hid: 'og:title',
@@ -46,7 +49,7 @@ const config: Configuration = {
       {
         hid: 'og:image',
         property: 'og:image',
-        content: 'https://covid19-mie.netlify.com/ogp.png'
+        content: path.join(DOMAIN_URL, 'ogp.png')
       },
       {
         hid: 'twitter:card',
@@ -66,7 +69,7 @@ const config: Configuration = {
       {
         hid: 'twitter:image',
         name: 'twitter:image',
-        content: 'https://covid19-mie.netlify.com/ogp.png'
+        content: path.join(DOMAIN_URL, 'ogp.png')
       }
     ],
     link: [


### PR DESCRIPTION
## 📝 関連issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- ogpのURLが古いドメインになっていたため、新しいドメインに変更しました
  - share linkのURLが古いURLになっているのでtwitter等で最近シェアされてる投稿でも古いドメインになってるぽい
- canonicalを変更
  - もし、古いドメインにしておきたい理由があればrevert or rebaseします！

## 📸 スクリーンショット / Screenshots

![古いドメインが新しいドメインになっているheadタグ](https://user-images.githubusercontent.com/18458057/77881326-b4f8fa00-7299-11ea-9c61-1f7677116b77.png)
